### PR TITLE
Fix a small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ note however that all three of the main methods (create, update and render) are 
 | Platform | Support Level | Version | Notes |
 |----|----|----|----|
 | Desktop | Full | 0.0.17 | Fedora and other Linux distributions officially supported first. Windows also known to work. No status on Apple computer builds available. Since this is a Java program, it *should just work* on any mainstream desktop OS. However, due to native libs this produce odd results on less common systems. |
-| Raspberry Pi 3B/B+ | Full | 0.0.17 | This requires custom builds of the native libs for LibGDX and LWJGL. Due to this, builds for this come slowly or only when tim epermits. The only currently supported OS for this is default Raspbian with OpenGL drivers activated and GPU memory boosted. This will be a full release in the future.|
+| Raspberry Pi 3B/B+ | Full | 0.0.17 | This requires custom builds of the native libs for LibGDX and LWJGL. Due to this, builds for this come slowly or only when time permits. The only currently supported OS for this is default Raspbian with OpenGL drivers activated and GPU memory boosted. This will be a full release in the future.|
 | Raspberry Pi 3A+ | Full | 0.0.17 | Same story as the 3B+. This board works great, and may replace the 3B+ as the primary target hardware. |
 |Clockwork Pi GameShell| Full | 0.0.17|Same as the Raspberry Pi's||
 


### PR DESCRIPTION
Typo in question: `tim epermits`, in the Supported Platforms section