### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/leikr-push.yml
+++ b/.github/workflows/leikr-push.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Set up JDK 15
       uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'zulu'
         java-version: '15'
     - name: Build with Gradle
       run: ./gradlew clean build desktop:deployLeikr -x test && ./gradlew javadoc


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK.